### PR TITLE
Se corrige error del modal al dejar la reseña

### DIFF
--- a/src/components/ReviewModal/ReviewModal.jsx
+++ b/src/components/ReviewModal/ReviewModal.jsx
@@ -7,6 +7,8 @@ import { postReviews } from '../../redux/actions';
 import { useParams } from 'react-router-dom';
 import { useAuth0 } from '@auth0/auth0-react';
 
+Modal.setAppElement('#root');
+
 const customStyles = {
   content: {
     top: '50%',


### PR DESCRIPTION
Se repara el error del modal en Profile del usuario al dejar la reseña

Antes aparecia este error:
![image](https://github.com/user-attachments/assets/d5c31ccc-c8cd-4d42-9d8c-13cb7f02affc)

Despues ya no:
![image](https://github.com/user-attachments/assets/6cfb5893-6e03-4971-9f86-6039ec80eb3a)

